### PR TITLE
buck build for 1.1 branch

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,8 @@
+[project]
+  ignore = .git
+
+[parser]
+  default_build_file_syntax = SKYLARK
+
+[cxx]
+  should_remap_host_platform = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Xcode
+xcuserdata/
+
+# JetBrains
+.idea/
+
+buck-out
+.buckd
+buckaroo
+buckaroo_macros.bzl
+.buckconfig.d
+.buckconfig.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: cpp
+sudo: true
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-6
+      - gcc-6
+  homebrew:
+    taps:
+      - facebook/fb
+    packages:
+      - buck
+
+os:
+  - linux
+  - osx
+
+env:
+  - BUCKAROO_VERSION=buckaroo-redux-alpha-12
+
+osx_image: xcode9.3
+
+before_install:
+  - ./travis/before-install-$TRAVIS_OS_NAME.sh
+
+script:
+  - ./buckaroo-client install
+  - buck build -c ui.superconsole=DISABLED //:minizip

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,9 @@
+cxx_library(
+  name = 'minizip',
+  exported_headers = glob(['*.h']),
+  srcs = glob(['*.c'], exclude=['iowin32.c']),
+  platform_srcs = [
+    ('win32.*', ['iowin32.c'])
+  ],
+  visibility = ['PUBLIC']
+)

--- a/buckaroo.lock.toml
+++ b/buckaroo.lock.toml
@@ -1,0 +1,2 @@
+manifest = "9edeaf63344b104839f8ffef46bd446abb022202febcb0b27618b7be2593edf6"
+

--- a/buckaroo.toml
+++ b/buckaroo.toml
@@ -1,0 +1,1 @@
+targets = [ "//:minizip" ]

--- a/travis/before-install-linux.sh
+++ b/travis/before-install-linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
+
+c++ --version
+g++ --version
+gcc --version
+
+sudo apt-get install -y equivs openjdk-8-jdk
+
+wget -O buck.deb https://github.com/facebook/buck/releases/download/v2018.10.29.01/buck.2018.10.29.01_all.deb
+sudo dpkg -i buck.deb
+buck --version
+
+wget https://github.com/LoopPerfect/buckaroo/releases/download/$BUCKAROO_VERSION/buckaroo-linux -O buckaroo-client
+chmod +x ./buckaroo-client
+./buckaroo-client version

--- a/travis/before-install-osx.sh
+++ b/travis/before-install-osx.sh
@@ -1,0 +1,3 @@
+wget https://github.com/LoopPerfect/buckaroo/releases/download/$BUCKAROO_VERSION/buckaroo-macos -O buckaroo-client
+chmod +x ./buckaroo-client
+./buckaroo-client version


### PR DESCRIPTION
mostly the same as https://github.com/buckaroo-pm/nmoinvaz-minizip/commit/2a750715a9217b47ff73f9aeefeeab2903a34cdd for the 1.2 branch, but without a reference to `'aes/*.c'`